### PR TITLE
Removed libcap from instructions.

### DIFF
--- a/README
+++ b/README
@@ -8,12 +8,11 @@ Installation on OS X:
 
 1. Install dependencies:
 
-brew install berkeley-db libnet libnids libpcap openssl
+brew install berkeley-db libnet libnids openssl
 
 2. Configure with correct paths:
 
 ./configure \
-  --with-libpcap=/usr/local/opt/libpcap \
   --with-openssl=/usr/local/opt/openssl \
   --with-libnet=/usr/local/opt/libnet \
   --with-libnids=/usr/local/opt/libnids \


### PR DESCRIPTION
@ggreer It looks like libcap is no longer installable through brew. Also simply removing libcap from `.configure` options yields a successful  installation, as stated by @fr3nch13 on https://github.com/ggreer/dsniff/issues/2

This PR updates the README by removing libcap from the installations instructions, since it is no longer needed.
