### PR TITLE
Upgrade to openssl-1-1-1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ tcpkill
 tcpnice
 urlsnarf
 webmitm
+webspy

--- a/ssh.c
+++ b/ssh.c
@@ -20,7 +20,6 @@
 #include <openssl/err.h>
 #include <openssl/rand.h>
 #include <openssl/md5.h>
-#include <openssl/bn.h>
 
 #include <err.h>
 #include <errno.h>

--- a/ssh.c
+++ b/ssh.c
@@ -122,7 +122,7 @@ get_bn(BIGNUM *bn, u_char **pp, int *lenp)
 }
 
 static u_char *
-ssh_session_id(u_char *cookie, BIGNUM *hostkey_n, BIGNUM *servkey_n)
+ssh_session_id(u_char *cookie, const BIGNUM *hostkey_n, const BIGNUM *servkey_n)
 {
 	static u_char sessid[16];
 	u_int i, j;
@@ -420,10 +420,18 @@ SSH_connect(SSH *ssh)
 	/* Get hostkey. */
 	ssh->ctx->hostkey = RSA_new();
 
+	host_bn_ctx = BN_CTX_new();
+	if (host_bn_ctx == NULL)
+	{
+		return (-1);
+	}
+
 	BN_CTX_start (host_bn_ctx);
 	host_bn_e = BN_CTX_get(host_bn_ctx);
 	host_bn_n = BN_CTX_get(host_bn_ctx);
 	RSA_set0_key(ssh->ctx->hostkey, host_bn_n, host_bn_n, NULL);
+
+	BN_CTX_end (host_bn_ctx);
 
 	SKIP(p, i, 4);
 	get_bn(host_bn_e, &p, &i);

--- a/sshcrypto.c
+++ b/sshcrypto.c
@@ -21,6 +21,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <string.h>
+
 #include "sshcrypto.h"
 
 struct blowfish_state {
@@ -29,8 +31,8 @@ struct blowfish_state {
 };
 
 struct des3_state {
-	des_key_schedule	k1, k2, k3;
-	des_cblock		iv1, iv2, iv3;
+	DES_key_schedule	k1, k2, k3;
+	DES_cblock		iv1, iv2, iv3;
 };
 
 void
@@ -39,10 +41,10 @@ rsa_public_encrypt(BIGNUM *out, BIGNUM *in, RSA *key)
 	u_char *inbuf, *outbuf;
 	int len, ilen, olen;
 
-	if (BN_num_bits(key->e) < 2 || !BN_is_odd(key->e))
-		errx(1, "rsa_public_encrypt() exponent too small or not odd");
+	//if (BN_num_bits(key->e) < 2 || !BN_is_odd(key->e))
+	//	errx(1, "rsa_public_encrypt() exponent too small or not odd");
 
-	olen = BN_num_bytes(key->n);
+	//olen = BN_num_bytes(key->n);
 	outbuf = malloc(olen);
 
 	ilen = BN_num_bytes(in);
@@ -71,7 +73,7 @@ rsa_private_decrypt(BIGNUM *out, BIGNUM *in, RSA *key)
 	u_char *inbuf, *outbuf;
 	int len, ilen, olen;
 
-	olen = BN_num_bytes(key->n);
+	//olen = BN_num_bytes(key->n);
 	outbuf = malloc(olen);
 
 	ilen = BN_num_bytes(in);
@@ -155,13 +157,13 @@ des3_init(u_char *sesskey, int len)
 	if ((state = malloc(sizeof(*state))) == NULL)
 		err(1, "malloc");
 
-	des_set_key((void *)sesskey, state->k1);
-	des_set_key((void *)(sesskey + 8), state->k2);
+	DES_set_key((void *)sesskey, &state->k1);
+	DES_set_key((void *)(sesskey + 8), &state->k2);
 
 	if (len <= 16)
-		des_set_key((void *)sesskey, state->k3);
+		DES_set_key((void *)sesskey, &state->k3);
 	else
-		des_set_key((void *)(sesskey + 16), state->k3);
+		DES_set_key((void *)(sesskey + 16), &state->k3);
 	
 	memset(state->iv1, 0, 8);
 	memset(state->iv2, 0, 8);
@@ -177,9 +179,9 @@ des3_encrypt(u_char *src, u_char *dst, int len, void *state)
 	estate = (struct des3_state *)state;
 	memcpy(estate->iv1, estate->iv2, 8);
 	
-	des_ncbc_encrypt(src, dst, len, estate->k1, &estate->iv1, DES_ENCRYPT);
-	des_ncbc_encrypt(dst, dst, len, estate->k2, &estate->iv2, DES_DECRYPT);
-	des_ncbc_encrypt(dst, dst, len, estate->k3, &estate->iv3, DES_ENCRYPT);
+	DES_ncbc_encrypt(src, dst, len, &estate->k1, &estate->iv1, DES_ENCRYPT);
+	DES_ncbc_encrypt(dst, dst, len, &estate->k2, &estate->iv2, DES_DECRYPT);
+	DES_ncbc_encrypt(dst, dst, len, &estate->k3, &estate->iv3, DES_ENCRYPT);
 }
 
 void
@@ -190,7 +192,7 @@ des3_decrypt(u_char *src, u_char *dst, int len, void *state)
 	dstate = (struct des3_state *)state;
 	memcpy(dstate->iv1, dstate->iv2, 8);
 	
-	des_ncbc_encrypt(src, dst, len, dstate->k3, &dstate->iv3, DES_DECRYPT);
-	des_ncbc_encrypt(dst, dst, len, dstate->k2, &dstate->iv2, DES_ENCRYPT);
-	des_ncbc_encrypt(dst, dst, len, dstate->k1, &dstate->iv1, DES_DECRYPT);
+	DES_ncbc_encrypt(src, dst, len, &dstate->k3, &dstate->iv3, DES_DECRYPT);
+	DES_ncbc_encrypt(dst, dst, len, &dstate->k2, &dstate->iv2, DES_ENCRYPT);
+	DES_ncbc_encrypt(dst, dst, len, &dstate->k1, &dstate->iv1, DES_DECRYPT);
 }

--- a/sshcrypto.c
+++ b/sshcrypto.c
@@ -38,13 +38,16 @@ struct des3_state {
 void
 rsa_public_encrypt(BIGNUM *out, BIGNUM *in, RSA *key)
 {
+	BIGNUM *bn_e, *bn_n;
 	u_char *inbuf, *outbuf;
 	int len, ilen, olen;
 
-	//if (BN_num_bits(key->e) < 2 || !BN_is_odd(key->e))
-	//	errx(1, "rsa_public_encrypt() exponent too small or not odd");
+	RSA_get0_key(key, &bn_n, &bn_e, NULL);
 
-	//olen = BN_num_bytes(key->n);
+	if (BN_num_bits(bn_e) < 2 || !BN_is_odd(bn_e))
+		errx(1, "rsa_public_encrypt() exponent too small or not odd");
+
+	olen = BN_num_bytes(bn_n);
 	outbuf = malloc(olen);
 
 	ilen = BN_num_bytes(in);
@@ -70,10 +73,13 @@ rsa_public_encrypt(BIGNUM *out, BIGNUM *in, RSA *key)
 void
 rsa_private_decrypt(BIGNUM *out, BIGNUM *in, RSA *key)
 {
+	BIGNUM *bn_n, *bn_e;
 	u_char *inbuf, *outbuf;
 	int len, ilen, olen;
+	
+	RSA_get0_key(key, &bn_n, &bn_e, NULL);
 
-	//olen = BN_num_bytes(key->n);
+	olen = BN_num_bytes(bn_n);
 	outbuf = malloc(olen);
 
 	ilen = BN_num_bytes(in);


### PR DESCRIPTION
@ggreer, 

Hello,

This is my attempt at upgrading your library to comply with (at least) openssl-1-1-1d (because that's the current version I have here).

We're facing problems only in _ssh.c_ and _sshcrypto.c_, the problem is the access to ''bignumbers'' contained in *RSA structure is not public anymore, we need to use the new API.

*RSA->key->e and *RSA->key->n are not accessible, we must use __RSA_get0_key()__, see https://wiki.openssl.org/index.php/OpenSSL_1.1.0_Changes.  This is what I did in __ssh.c__

 In __ssh.c->connect()__ an RSA context is created, we need to use the new API (**BN_new()** is not available anymore), 
good infos here https://stackoverflow.com/questions/16437475/openssl-bn-ctx-usage